### PR TITLE
Image Query Endpoint with tag and employee ID 

### DIFF
--- a/drms-api/main.py
+++ b/drms-api/main.py
@@ -1,9 +1,9 @@
 # main2.py
-from fastapi import FastAPI, UploadFile, File, Form
+from fastapi import FastAPI, UploadFile, File, Form, Query
 from fastapi.middleware.cors import CORSMiddleware
 from models import EmployeeInput, UpdateEmployeeInput
 import employee_services, images_services
-import yolo_api
+from typing import List, Optional
 app = FastAPI()
 
 app.add_middleware(
@@ -41,3 +41,9 @@ async def detect_tags(emp_id:str = Form(...),  file: UploadFile = File(...)):
     return images_services.add_image_metadata(emp_id, file)
 
     
+#Query images
+@app.get("/images/query")
+def get_images(
+    tags: list[str] = Query(..., description='List of tags to filter images'), 
+    emp_id: Optional[str] = None):
+    return images_services.get_images_info(tags, emp_id)


### PR DESCRIPTION
This PR introduces a new `GET` endpoint to query stored images based on tag filters and optionally by employee ID.

## Key Changes:

- **New GET route**: `/images/query` in `main.py`
  - Accepts `tags` as a required list of strings via query parameters.
  - Accepts `emp_id` as an optional query parameter.

- **Updated logic in `images_services.py`**:
  - Performs case-insensitive tag matching.
  - Uses set intersection to check for at least one matching tag.
  - Filters results by `emp_id` if provided.
  - Returns 404 if no matching images are found.
  - Returns 500 for unexpected exceptions with error details.

- Fully compatible with OpenAPI/Swagger UI for testing.