### PR TITLE
Improve S3 File Upload for Better Compatibility and Rendering

### DIFF
--- a/drms-ui/src/components/QueriyImages.jsx
+++ b/drms-ui/src/components/QueriyImages.jsx
@@ -107,7 +107,7 @@ const QueriyImages = () => {
                 <p className="text-gray-700"><strong>Image Id: </strong> {img.img_id}</p>
                 <p className="text-gray-600"><strong>Employee ID:</strong> {img.emp_id}</p>
                 <p className="text-gray-600"><strong>Tags:</strong> {img.tags?.join(', ')}</p>
-                <p className="text-gray-600"><strong>Size:</strong> {img.size} - {img.dimension}</p>
+                <p className="text-gray-600"><strong>Size:</strong> {img.size} KB - {img.dimension}</p>
               </div>
             ))}
           </div>


### PR DESCRIPTION
This PR addresses a problem where files uploaded to Amazon S3—particularly images—could not be correctly rendered in the UI or downloaded properly. The issue was due to missing `Content-Type` metadata during upload. This update ensures that uploaded files retain their correct MIME types, enabling proper rendering and usage via pre-signed URLs.

## Summary of Changes:
- Set appropriate `Content-Type` using `ExtraArgs` in `upload_fileobj`.

- Retrieved MIME type dynamically from FastAPI’s `UploadFile`.

- (Optional) Ensured the file stream is correctly positioned before upload using `file.file.seek(0)`.

- Enabled UI to properly display and download files using pre-signed URLs.