### PR TITLE
Unit Tests for Employees and Images Services APIs

### DIFF
--- a/drms-api/src/employee_services.py
+++ b/drms-api/src/employee_services.py
@@ -97,7 +97,7 @@ def update_employee(u_id: str, update_data: UpdateEmployeeInput):
 
         updated = False
         for emp in item['employee']:
-            if emp['u_id'] == u_id:
+            if emp['u_id'] == u_id and emp['active']:
                 emp.update({"name": update_data.name})
                 updated = True
                 break

--- a/drms-api/test/test_employee_api.py
+++ b/drms-api/test/test_employee_api.py
@@ -1,0 +1,157 @@
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import patch, MagicMock
+from main import app
+import employee_services, copy
+
+
+client = TestClient(app)
+demo_db_const = {
+        'Item' : {
+            'id' : 'Ariful_Islam',
+            'employee': [
+                {
+                    'u_id': 'EMP001',
+                    'name' : 'Arif',
+                    'active': True
+                },
+                {
+                    'u_id': 'EMP002',
+                    'name' : 'Shakil',
+                    'active': False
+                },
+                {
+                    'u_id': 'EMP003',
+                    'name' : 'Tuhin',
+                    'active': True
+                }
+            ]
+        }
+    }
+
+active_demo_db = [
+            {
+                'u_id': 'EMP001',
+                'name' : 'Arif',
+                'active': True
+            },
+            {
+                'u_id': 'EMP003',
+                'name' : 'Tuhin',
+                'active': True
+            }
+        ]
+
+
+
+################ Testing Add Employee API ###########################
+@patch("employee_services.employee_table") 
+def test_add_employee(mock_table):
+    # mock_create_id.return_value = 'EMP001'
+    mock_table.get_item.return_value = {}
+    mock_table.put_table.return_value = {}
+
+    payload = {'name': 'Ariful Islam'}
+    response = client.post("/employee/add", json=payload)
+    assert response.status_code == 200
+    assert response.json()['message'] == "Employee added successfully"
+    assert response.json()['u_id'] == 'EMP001'
+
+    demo_db = copy.deepcopy(demo_db_const)
+    mock_table.get_item.return_value = demo_db
+    payload = {'name': 'Ariful Islam Shakil'}
+    response = client.post("/employee/add", json=payload)
+    assert response.status_code == 200
+    assert response.json()['message'] == "Employee added successfully"
+    assert response.json()['u_id'] == 'EMP004'
+
+
+def test_add_employee_invalid():
+    payload = {'name': '12'}
+    response = client.post('/employee/add', json=payload)
+    assert response.status_code == 500
+    assert '400: Invalid name: must contain non-digit characters.' in response.json()['detail']
+
+    payload = {'name': ' '}
+    response = client.post('/employee/add', json=payload)
+    assert response.status_code == 500
+    assert '400: Invalid name: must contain non-digit characters.' in response.json()['detail']
+
+
+
+
+################ Testing Get Employees API ###########################
+@patch('employee_services.employee_table')
+def test_get_employees(mock_table):
+
+    demo_db = copy.deepcopy(demo_db_const)
+    mock_table.get_item.return_value = demo_db
+    response = client.get('/employees/getEmployees')
+    assert response.status_code == 200
+    assert response.json()['employees'] == active_demo_db
+
+    mock_table.get_item.side_effect = Exception('DynamoDB Failure')
+    response = client.get('/employees/getEmployees')
+    assert response.status_code == 500
+    assert "DynamoDB Failure" in response.json()['detail']
+
+@patch('employee_services.employee_table')
+def test_get_employee_by_id(mock_table):
+    demo_db = copy.deepcopy(demo_db_const)
+    mock_table.get_item.return_value = demo_db
+    response = client.get('/employees/getEmployee/EMP001')
+    assert response.status_code == 200
+    assert response.json() == active_demo_db[0]
+
+    response = client.get('/employees/getEmployee/EMP002')
+    assert response.status_code == 500
+    assert '404: Employee not found' in response.json()['detail']
+
+    mock_table.get_item.return_value = {}
+    response = client.get('/employees/getEmployee/EMP002')
+    assert response.status_code == 500
+    assert '404: Employee list not found' in response.json()['detail']
+
+
+
+################ Testing Update Employees API ##########################
+@patch('employee_services.employee_table')
+def test_update_employee(mock_table):
+    demo_db = copy.deepcopy(demo_db_const)
+    mock_table.get_item.return_value = demo_db
+    response = client.put("/employee/update/EMP001", json={'name': 'Shakil Updated'})
+    assert response.status_code == 200
+    assert "Employee with u_id EMP001 updated successfully" in response.json()['message']
+
+    demo_db = copy.deepcopy(demo_db_const)
+    mock_table.get_item.return_value = demo_db
+    response = client.put("/employee/update/EMP002", json={'name': 'Shakil Updated'})
+    assert response.status_code == 500
+    assert"404: Employee with u_id EMP002 not found" in response.json()['detail']
+
+
+################ Testing Delete Employees API ##########################
+@patch('employee_services.employee_table')
+def test_delete_employee(mock_table):
+    demo_db = copy.deepcopy(demo_db_const)
+    mock_table.get_item.return_value = demo_db
+    mock_table.put_table.return_value = {}
+    response = client.delete('/employees/delete/EMP001')
+    assert response.status_code == 200
+    assert response.json()['message'] == 'Employee with u_id EMP001 deleted successfully'
+
+    demo_db = copy.deepcopy(demo_db_const)
+    mock_table.get_item.return_value = demo_db
+    mock_table.put_table.return_value = {}
+    response = client.delete('/employees/delete/EMP005')
+    assert response.status_code == 500
+    assert response.json()['detail'] == '405: Employee with id EMP005 not found'
+
+    mock_table.get_item.return_value = {} 
+    response = client.delete('/employees/delete/EMP005')
+    assert response.status_code == 500
+    assert response.json()['detail'] == '404: Employee list not found'
+
+    
+    ######################## Testing Images services #################
+    

--- a/drms-api/test/test_images_api.py
+++ b/drms-api/test/test_images_api.py
@@ -1,0 +1,95 @@
+from fastapi.testclient import TestClient
+from unittest.mock import patch
+from main import app
+import copy
+from io import BytesIO
+
+client = TestClient(app)
+
+demo_image_data_const = {
+    'Item': {
+        'id': 'Arifs_images',
+        'images_data': [
+            {
+                'img_id': 'IMG001',
+                'emp_id': 'EMP001',
+                'size': '125 kb',
+                'dimension': '32 x 32',
+                'created_time': '12:12:2025',
+                'tags': ['person', 'cat'],
+                's3path': 'Ariful Islam/images1.jpg'
+            },
+            {
+                'img_id': 'IMG002',
+                'emp_id': 'EMP005',
+                'size': '256 kb',
+                'dimension': '64 x 64',
+                'created_time': '11:12:2025',
+                'tags': ['dog', 'cat'],
+                's3path': 'Ariful Islam/images2.jpg'
+            }
+        ]
+    }
+}
+
+
+############## Testing Upload images ####################
+@patch('images_services.image_table')
+@patch('images_services.upload_to_s3', return_value='Ariful_Islam/image3.jpg')
+@patch('yolo_api.get_image_tags_yolov8_file', return_value=(["bird", "cat"], '300x200', '520 kb'))
+def test_add_image_metadata(mock_yolo, mock_upload_s3, mock_image_table):
+    demo_image_data = copy.deepcopy(demo_image_data_const)
+    mock_image_table.get_item.return_value = demo_image_data
+    mock_image_table.put_item.return_value = {}
+
+    file = BytesIO(b"fake image bytes")
+    file.name = "test.jpg"
+
+    response = client.post(
+        "/images/upload/",
+        data={"emp_id": "EMP006"},
+        files={"file": ("test.jpg", file, "image/jpeg")}
+    )
+
+    assert response.status_code == 200
+    assert response.json()['message'] == 'Image metadata added successfully'
+    assert response.json()['img_id'] == 'IMG003'
+
+    mock_image_table.get_item.return_value = {}
+    response = client.post(
+        "/images/upload/",
+        data={"emp_id": "EMP006"},
+        files={"file": ("test.jpg", file, "image/jpeg")}
+    )
+    assert response.status_code == 200
+    assert response.json()['message'] == 'Image metadata added successfully'
+    assert response.json()['img_id'] == 'IMG001'
+
+    mock_image_table.get_item.side_effect = Exception("DynamoDB Error")
+    response = client.post(
+        "/images/upload/",
+        data={"emp_id": "EMP006"},
+        files={"file": ("test.jpg", file, "image/jpeg")}
+    )
+    assert response.status_code == 500
+    assert response.json()['detail'] == 'DynamoDB Error'
+ 
+
+
+############### Testing Query Images ###########################
+@patch('images_services.image_table')
+@patch('images_services.generate_presigned_url', return_value='http://download/link/image3')
+def test_query_image(mock_url, mock_table):
+    demo_image_data = copy.deepcopy(demo_image_data_const)
+    mock_table.get_item.return_value = demo_image_data
+    response = client.get("/images/query", params=[("tags", "cat"), ("tags", "person")])
+    assert response.status_code == 200
+    assert response.json()['images'] == demo_image_data['Item']['images_data']
+
+    response = client.get("/images/query", params=[("tags", "cat"), ("emp_id", "EMP001")])
+    assert response.status_code == 200
+    assert response.json()['images'] == [demo_image_data['Item']['images_data'][0]]
+
+    response = client.get("/images/query", params=[("tags", "person"), ("emp_id", "EMP005")])
+    assert response.status_code == 500
+    assert response.json()['detail'] == '404: Tags or Employee not matched'


### PR DESCRIPTION
This PR adds unit tests for key endpoints in the **Employees** and **Images** services of the DRMS project, ensuring correctness and robustness using `pytest` and FastAPI's `TestClient`.

## Changes include:
- Employee API Tests

  - Add employee (valid/invalid)

  - Get all active employees

  - Get/update/delete employee by ID

- Image API Tests

  - Upload image with metadata (with/without existing data)

  - Query images by tags and emp_id

- Mocked External Services

  - DynamoDB operations

  - YOLO model tagging

  - S3 upload & presigned URL